### PR TITLE
Allow BlockingPublisher.channel to be deleted to allow automatic recreation

### DIFF
--- a/pikachewie/publisher.py
+++ b/pikachewie/publisher.py
@@ -104,6 +104,10 @@ class BlockingPublisher(PublisherMixin, object):
             self._channel.confirm_delivery()
         return self._channel
 
+    @channel.deleter
+    def channel(self):
+        self._channel = None
+
 
 class JSONPublisherMixin(PublisherMixin):
     """Publisher Mixin that JSON-serializes the message payload."""


### PR DESCRIPTION
This allows external interaction by a PikaChewie client if it detects an error and wants to force PikaChewie to reestablish a valid connection.